### PR TITLE
Rename global constants and prevent stalled mining

### DIFF
--- a/block.go
+++ b/block.go
@@ -44,7 +44,7 @@ func NewBlock(previous BlockID, height int64, target, chainWork BlockID, transac
 	*Block, error) {
 
 	// enforce the hard cap transaction limit
-	if len(transactions) > MAX_TRANSACTIONS_PER_BLOCK {
+	if len(transactions) > MaxTransactionsPerBlock {
 		return nil, fmt.Errorf("Transaction list size exceeds limit per block")
 	}
 
@@ -63,7 +63,7 @@ func NewBlock(previous BlockID, height int64, target, chainWork BlockID, transac
 			Time:             time.Now().Unix(), // just use the system time
 			Target:           target,
 			ChainWork:        computeChainWork(target, chainWork),
-			Nonce:            rand.Int63n(MAX_NUMBER),
+			Nonce:            rand.Int63n(MaxNumber),
 			Height:           height,
 			TransactionCount: int32(len(transactions)),
 		},

--- a/block_header_hasher_test.go
+++ b/block_header_hasher_test.go
@@ -28,11 +28,11 @@ func makeTestBlock(n int) (*Block, error) {
 		privKey2 := ed25519.NewKeyFromSeed([]byte(seed2))
 		pubKey2 := privKey2.Public().(ed25519.PublicKey)
 
-		matures := MAX_NUMBER
-		expires := MAX_NUMBER
-		height := MAX_NUMBER
-		amount := int64(MAX_MONEY)
-		fee := int64(MAX_MONEY)
+		matures := MaxNumber
+		expires := MaxNumber
+		height := MaxNumber
+		amount := int64(MaxMoney)
+		fee := int64(MaxMoney)
 
 		tx := NewTransaction(pubKey, pubKey2, amount, fee, matures, height, expires, "こんにちは")
 		if len(tx.Memo) != 15 {
@@ -49,7 +49,7 @@ func makeTestBlock(n int) (*Block, error) {
 	}
 
 	// create the block
-	targetBytes, err := hex.DecodeString(INITIAL_TARGET)
+	targetBytes, err := hex.DecodeString(InitialTarget)
 	if err != nil {
 		return nil, err
 	}

--- a/block_storage_disk_test.go
+++ b/block_storage_disk_test.go
@@ -17,10 +17,10 @@ func TestEncodeBlockHeader(t *testing.T) {
 	}
 
 	// create a coinbase
-	tx := NewTransaction(nil, pubKey, INITIAL_COINBASE_REWARD, 0, 0, 0, 0, "hello")
+	tx := NewTransaction(nil, pubKey, InitialCoinbaseReward, 0, 0, 0, 0, "hello")
 
 	// create a block
-	targetBytes, err := hex.DecodeString(INITIAL_TARGET)
+	targetBytes, err := hex.DecodeString(InitialTarget)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/main.go
+++ b/client/main.go
@@ -30,7 +30,7 @@ func main() {
 	pubKeyPtr := flag.String("pubkey", "", "A public key which receives newly mined block rewards")
 	dataDirPtr := flag.String("datadir", "", "Path to a directory to save block chain data")
 	memoPtr := flag.String("memo", "", "A memo to include in newly mined blocks")
-	portPtr := flag.Int("port", DEFAULT_CRUZBIT_PORT, "Port to listen for incoming peer connections")
+	portPtr := flag.Int("port", DefaultCruzbitPort, "Port to listen for incoming peer connections")
 	peerPtr := flag.String("peer", "", "Address of a peer to connect to")
 	upnpPtr := flag.Bool("upnp", false, "Attempt to forward the cruzbit port on your router with UPnP")
 	dnsSeedPtr := flag.Bool("dnsseed", false, "Run a DNS server to allow others to find peers")
@@ -42,7 +42,7 @@ func main() {
 	keyFilePtr := flag.String("keyfile", "", "Path to a file containing public keys to use when mining")
 	tlsCertPtr := flag.String("tlscert", "", "Path to a file containing a PEM-encoded X.509 certificate to use with TLS")
 	tlsKeyPtr := flag.String("tlskey", "", "Path to a file containing a PEM-encoded private key to use with TLS")
-	inLimitPtr := flag.Int("inlimit", MAX_INBOUND_PEER_CONNECTIONS, "Limit for the number of inbound peer connections.")
+	inLimitPtr := flag.Int("inlimit", MaxInboundPeerConnections, "Limit for the number of inbound peer connections.")
 	banListPtr := flag.String("banlist", "", "Path to a file containing a list of banned host addresses")
 	flag.Parse()
 
@@ -59,7 +59,7 @@ func main() {
 	if len(*peerPtr) != 0 {
 		// add default port, if one was not supplied
 		if i := strings.LastIndex(*peerPtr, ":"); i < 0 {
-			*peerPtr = *peerPtr + ":" + strconv.Itoa(DEFAULT_CRUZBIT_PORT)
+			*peerPtr = *peerPtr + ":" + strconv.Itoa(DefaultCruzbitPort)
 		}
 	}
 

--- a/constants.go
+++ b/constants.go
@@ -7,73 +7,74 @@ package cruzbit
 // we could have played with these but we're introducing significant enough changes
 // already IMO, so let's keep the scope of this experiment as small as we can
 
-const CRUZBITS_PER_CRUZ = 100000000
+const CruzbitsPerCruz = 100000000
 
-const INITIAL_COINBASE_REWARD = 50 * CRUZBITS_PER_CRUZ
+const InitialCoinbaseReward = 50 * CruzbitsPerCruz
 
-const COINBASE_MATURITY = 100 // blocks
+const CoinbaseMaturity = 100 // blocks
 
-const INITIAL_TARGET = "00000000ffff0000000000000000000000000000000000000000000000000000"
+const InitialTarget = "00000000ffff0000000000000000000000000000000000000000000000000000"
 
-const MAX_FUTURE_SECONDS = 2 * 60 * 60 // 2 hours
+const MaxFutureSeconds = 2 * 60 * 60 // 2 hours
 
-const MAX_MONEY = 21000000 * CRUZBITS_PER_CRUZ
+const MaxMoney = 21000000 * CruzbitsPerCruz
 
-const RETARGET_INTERVAL = 2016 // 2 weeks in blocks
+const RetargetInterval = 2016 // 2 weeks in blocks
 
-const RETARGET_TIME = 1209600 // 2 weeks in seconds
+const RetargetTime = 1209600 // 2 weeks in seconds
 
-const TARGET_SPACING = 600 // every 10 minutes
+const TargetSpacing = 600 // every 10 minutes
 
-const NUM_BLOCKS_FOR_MEDIAN_TMESTAMP = 11
+const NumBlocksForMedianTmestamp = 11
 
-const BLOCKS_UNTIL_REWARD_HALVING = 210000 // 4 years in blocks
+const BlocksUntilRewardHalving = 210000 // 4 years in blocks
 
 // the below value affects ledger consensus and comes from bitcoin cash
 
-const RETARGET_SMA_WINDOW = 144 // 1 day in blocks
+const RetargetSmaWindow = 144 // 1 day in blocks
 
 // the below values affect ledger consensus and are new as of our ledger
 
-const INITIAL_MAX_TRANSACTIONS_PER_BLOCK = 10000 // 16.666... tx/sec, ~4 MBish in JSON
+const InitialMaxTransactionsPerBlock = 10000 // 16.666... tx/sec, ~4 MBish in JSON
 
-const BLOCKS_UNTIL_TRANSACTIONS_PER_BLOCK_DOUBLING = 105000 // 2 years in blocks
+const BlocksUntilTransactionsPerBlockDoubling = 105000 // 2 years in blocks
 
-const MAX_TRANSACTIONS_PER_BLOCK = 1<<31 - 1
+const MaxTransactionsPerBlock = 1<<31 - 1
 
-const MAX_TRANSACTIONS_PER_BLOCK_EXCEEDED_AT_HEIGHT = 1852032 // pre-calculated
+const MaxTransactionsPerBlockExceededAtHeight = 1852032 // pre-calculated
 
-const BLOCKS_UNTIL_NEW_SERIES = 1008 // 1 week in blocks
+const BlocksUntilNewSeries = 1008 // 1 week in blocks
 
-const MAX_MEMO_LENGTH = 100 // bytes (ascii/utf8 only)
+const MaxMemoLength = 100 // bytes (ascii/utf8 only)
 
 // given our JSON protocol we should respect Javascript's Number.MAX_SAFE_INTEGER value
-const MAX_NUMBER int64 = 1<<53 - 1
+const MaxNumber int64 = 1<<53 - 1
 
 // height at which we switch from bitcoin's difficulty adjustment algorithm to bitcoin cash's algorithm
-const BITCOIN_CASH_RETARGET_ALGORITHM_HEIGHT = 28861
+const BitcoinCashRetargetAlgorithmHeight = 28861
 
 // the below values only affect peering behavior and do not affect ledger consensus
 
-const DEFAULT_CRUZBIT_PORT = 8831
+const DefaultCruzbitPort = 8831
 
-const MAX_OUTBOUND_PEER_CONNECTIONS = 8
+const MaxOutboundPeerConnections = 8
 
-const MAX_INBOUND_PEER_CONNECTIONS = 128
+const MaxInboundPeerConnections = 128
 
-const MAX_INBOUND_PEER_CONNECTIONS_FROM_SAME_HOST = 4
+const MaxInboundPeerConnectionsFromSameHost = 4
 
-const MAX_TIP_AGE = 24 * 60 * 60
+// MaxTipAge is originally 24 hours, but has been increased to 30 days to prevent deadlock caused by low mining volume
+const MaxTipAge = 24 * 60 * 60 * 30
 
-const MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024 // doesn't apply to blocks
+const MaxProtocolMessageLength = 2 * 1024 * 1024 // doesn't apply to blocks
 
 // the below values are mining policy and also do not affect ledger consensus
 
 // if you change this it needs to be less than the maximum at the current height
-const MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK = INITIAL_MAX_TRANSACTIONS_PER_BLOCK
+const MaxTransactionsToIncludePerBlock = InitialMaxTransactionsPerBlock
 
-const MAX_TRANSACTION_QUEUE_LENGTH = MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK * 10
+const MaxTransactionQueueLength = MaxTransactionsToIncludePerBlock * 10
 
-const MIN_FEE_CRUZBITS = 1000000 // 0.01 cruz
+const MinFeeCruzbits = 1000000 // 0.01 cruz
 
-const MIN_AMOUNT_CRUZBITS = 1000000 // 0.01 cruz
+const MinAmountCruzbits = 1000000 // 0.01 cruz

--- a/dns.go
+++ b/dns.go
@@ -61,7 +61,7 @@ func (d *DNSSeeder) handleQuery(m *dns.Msg, externalIP string) {
 					return
 				}
 				ip, port, _ := net.SplitHostPort(addr)
-				if port != strconv.Itoa(DEFAULT_CRUZBIT_PORT) {
+				if port != strconv.Itoa(DefaultCruzbitPort) {
 					continue
 				}
 				rr, err := dns.NewRR(fmt.Sprintf("%s A %s", q.Name, ip))
@@ -141,7 +141,7 @@ func dnsQueryForPeers() ([]string, error) {
 		for _, answer := range r.Answer {
 			a := answer.(*dns.A)
 			log.Printf("Seeder returned: %s\n", a.A.String())
-			peers = append(peers, a.A.String()+":"+strconv.Itoa(DEFAULT_CRUZBIT_PORT))
+			peers = append(peers, a.A.String()+":"+strconv.Itoa(DefaultCruzbitPort))
 		}
 	}
 	return peers, nil

--- a/inspector/main.go
+++ b/inspector/main.go
@@ -110,7 +110,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		log.Printf("Current balance: %.8f\n", aurora.Bold(float64(balance)/CRUZBITS_PER_CRUZ))
+		log.Printf("Current balance: %.8f\n", aurora.Bold(float64(balance)/CruzbitsPerCruz))
 
 	case "balance_at":
 		if pubKey == nil {
@@ -120,7 +120,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		log.Printf("Balance at height %d: %.8f\n", *heightPtr, aurora.Bold(float64(balance)/CRUZBITS_PER_CRUZ))
+		log.Printf("Balance at height %d: %.8f\n", *heightPtr, aurora.Bold(float64(balance)/CruzbitsPerCruz))
 
 	case "block_at":
 		id, err := ledger.GetBlockIDForHeight(int64(*heightPtr))
@@ -296,16 +296,16 @@ func verify(ledger Ledger, blockStore BlockStorage, pubKey ed25519.PublicKey, he
 
 	if pubKey == nil {
 		// compute expected total balance
-		if height-COINBASE_MATURITY >= 0 {
+		if height-CoinbaseMaturity >= 0 {
 			// sum all mature rewards per schedule
 			var i int64
-			for i = 0; i <= height-COINBASE_MATURITY; i++ {
+			for i = 0; i <= height-CoinbaseMaturity; i++ {
 				expect += BlockCreationReward(i)
 			}
 
 			// account for fees included in immature rewards
 			var immatureFees int64
-			for i = height - COINBASE_MATURITY + 1; i <= height; i++ {
+			for i = height - CoinbaseMaturity + 1; i <= height; i++ {
 				if i < 0 {
 					continue
 				}
@@ -352,13 +352,13 @@ func verify(ledger Ledger, blockStore BlockStorage, pubKey ed25519.PublicKey, he
 		log.Fatalf("%s: At height %d, we expected %.8f cruz but we found %.8f\n",
 			aurora.Bold(aurora.Red("FAILURE")),
 			aurora.Bold(height),
-			aurora.Bold(float64(expect)/CRUZBITS_PER_CRUZ),
-			aurora.Bold(float64(found)/CRUZBITS_PER_CRUZ))
+			aurora.Bold(float64(expect)/CruzbitsPerCruz),
+			aurora.Bold(float64(found)/CruzbitsPerCruz))
 	}
 
 	log.Printf("%s: At height %d, we expected %.8f cruz and we found %.8f\n",
 		aurora.Bold(aurora.Green("SUCCESS")),
 		aurora.Bold(height),
-		aurora.Bold(float64(expect)/CRUZBITS_PER_CRUZ),
-		aurora.Bold(float64(found)/CRUZBITS_PER_CRUZ))
+		aurora.Bold(float64(expect)/CruzbitsPerCruz),
+		aurora.Bold(float64(found)/CruzbitsPerCruz))
 }

--- a/ledger_disk.go
+++ b/ledger_disk.go
@@ -177,15 +177,15 @@ func (l LedgerDisk) ConnectBlock(id BlockID, block *Block) ([]TransactionID, err
 			// depend on coinbases.
 			txToApply = nil
 
-			if block.Header.Height-COINBASE_MATURITY >= 0 {
+			if block.Header.Height-CoinbaseMaturity >= 0 {
 				// mature the coinbase from 100 blocks ago now
-				oldID, err := l.GetBlockIDForHeight(block.Header.Height - COINBASE_MATURITY)
+				oldID, err := l.GetBlockIDForHeight(block.Header.Height - CoinbaseMaturity)
 				if err != nil {
 					return nil, err
 				}
 				if oldID == nil {
 					return nil, fmt.Errorf("Missing block at height %d\n",
-						block.Header.Height-COINBASE_MATURITY)
+						block.Header.Height-CoinbaseMaturity)
 				}
 
 				// we could store the last 100 coinbases on our own in memory if we end up needing to
@@ -273,8 +273,8 @@ func (l LedgerDisk) ConnectBlock(id BlockID, block *Block) ([]TransactionID, err
 	batch.Put(key, ctBytes)
 
 	// prune historic transaction and public key transaction indices now
-	if l.prune && block.Header.Height >= 2*BLOCKS_UNTIL_NEW_SERIES {
-		if err := l.pruneIndices(block.Header.Height-2*BLOCKS_UNTIL_NEW_SERIES, batch); err != nil {
+	if l.prune && block.Header.Height >= 2*BlocksUntilNewSeries {
+		if err := l.pruneIndices(block.Header.Height-2*BlocksUntilNewSeries, batch); err != nil {
 			return nil, err
 		}
 	}
@@ -332,15 +332,15 @@ func (l LedgerDisk) DisconnectBlock(id BlockID, block *Block) ([]TransactionID, 
 			// coinbase doesn't affect recipient balance for 100 more blocks
 			txToUndo = nil
 
-			if block.Header.Height-COINBASE_MATURITY >= 0 {
+			if block.Header.Height-CoinbaseMaturity >= 0 {
 				// undo the effect of the coinbase from 100 blocks ago now
-				oldID, err := l.GetBlockIDForHeight(block.Header.Height - COINBASE_MATURITY)
+				oldID, err := l.GetBlockIDForHeight(block.Header.Height - CoinbaseMaturity)
 				if err != nil {
 					return nil, err
 				}
 				if oldID == nil {
 					return nil, fmt.Errorf("Missing block at height %d\n",
-						block.Header.Height-COINBASE_MATURITY)
+						block.Header.Height-CoinbaseMaturity)
 				}
 				oldTx, _, err := l.blockStore.GetTransaction(*oldID, 0)
 				if err != nil {
@@ -422,8 +422,8 @@ func (l LedgerDisk) DisconnectBlock(id BlockID, block *Block) ([]TransactionID, 
 	batch.Put(key, ctBytes)
 
 	// restore historic indices now
-	if l.prune && block.Header.Height >= 2*BLOCKS_UNTIL_NEW_SERIES {
-		if err := l.restoreIndices(block.Header.Height-2*BLOCKS_UNTIL_NEW_SERIES, batch); err != nil {
+	if l.prune && block.Header.Height >= 2*BlocksUntilNewSeries {
+		if err := l.restoreIndices(block.Header.Height-2*BlocksUntilNewSeries, batch); err != nil {
 			return nil, err
 		}
 	}
@@ -853,7 +853,7 @@ func (l LedgerDisk) GetPublicKeyBalanceAt(pubKey ed25519.PublicKey, height int64
 			return 0, err
 		}
 
-		if index == 0 && height > currentHeight-COINBASE_MATURITY {
+		if index == 0 && height > currentHeight-CoinbaseMaturity {
 			// coinbase isn't mature
 			continue
 		}

--- a/miner.go
+++ b/miner.go
@@ -154,8 +154,8 @@ func (m *Miner) run() {
 				continue
 			}
 
-			if MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK != 0 &&
-				len(block.Transactions) >= MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK {
+			if MaxTransactionsToIncludePerBlock != 0 &&
+				len(block.Transactions) >= MaxTransactionsToIncludePerBlock {
 				log.Printf("Per-block transaction limit hit (%d)\n", len(block.Transactions))
 				continue
 			}
@@ -229,7 +229,7 @@ func (m *Miner) run() {
 			} else {
 				// no solution yet
 				block.Header.Nonce += attempts
-				if block.Header.Nonce > MAX_NUMBER {
+				if block.Header.Nonce > MaxNumber {
 					block.Header.Nonce = 0
 				}
 			}
@@ -256,7 +256,7 @@ func createNextBlock(tipID BlockID, tipHeader *BlockHeader, txQueue TransactionQ
 	blockStore BlockStorage, ledger Ledger, pubKey ed25519.PublicKey, memo string) (*Block, error) {
 
 	// fetch transactions to confirm from the queue
-	txs := txQueue.Get(MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK - 1)
+	txs := txQueue.Get(MaxTransactionsToIncludePerBlock - 1)
 
 	// calculate total fees
 	var fees int64 = 0

--- a/peer.go
+++ b/peer.go
@@ -233,7 +233,7 @@ func (p *Peer) run() {
 		defer p.processor.UnregisterForTipChange(tipChangeChan)
 
 		// register to hear about new transactions
-		newTxChan := make(chan NewTx, MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK)
+		newTxChan := make(chan NewTx, MaxTransactionsToIncludePerBlock)
 		p.processor.RegisterForNewTransactions(newTxChan)
 		defer p.processor.UnregisterForNewTransactions(newTxChan)
 
@@ -414,7 +414,7 @@ func (p *Peer) run() {
 					break
 				}
 				txCount := len(p.workBlock.Transactions)
-				if txCount == MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK {
+				if txCount == MaxTransactionsToIncludePerBlock {
 					// already at capacity
 					break
 				}
@@ -492,7 +492,7 @@ func (p *Peer) run() {
 			}
 
 			// hangup if the peer is sending oversized messages
-			if m.Type != "block" && len(message) > MAX_PROTOCOL_MESSAGE_LENGTH {
+			if m.Type != "block" && len(message) > MaxProtocolMessageLength {
 				log.Printf("Received too large (%d bytes) of a '%s' message, from: %s",
 					len(message), m.Type, p.conn.RemoteAddr())
 				return
@@ -717,8 +717,8 @@ func (p *Peer) run() {
 				outChan <- Message{
 					Type: "transaction_relay_policy",
 					Body: TransactionRelayPolicyMessage{
-						MinFee:    MIN_FEE_CRUZBITS,
-						MinAmount: MIN_AMOUNT_CRUZBITS,
+						MinFee:    MinFeeCruzbits,
+						MinAmount: MinAmountCruzbits,
 					},
 				}
 
@@ -1559,8 +1559,8 @@ func (p *Peer) onGetWork(gw GetWorkMessage) {
 		err = fmt.Errorf("Peer already has work")
 	} else if len(gw.PublicKeys) == 0 {
 		err = fmt.Errorf("No public keys specified")
-	} else if len(gw.Memo) > MAX_MEMO_LENGTH {
-		err = fmt.Errorf("Max memo length (%d) exceeded: %d", MAX_MEMO_LENGTH, len(gw.Memo))
+	} else if len(gw.Memo) > MaxMemoLength {
+		err = fmt.Errorf("Max memo length (%d) exceeded: %d", MaxMemoLength, len(gw.Memo))
 	} else {
 		var tipID *BlockID
 		var tipHeader *BlockHeader

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -334,7 +334,7 @@ func (p *PeerManager) connectToPeers(ctx context.Context) error {
 		want = 1
 	} else {
 		// otherwise try to keep us maximally connected
-		want = MAX_OUTBOUND_PEER_CONNECTIONS
+		want = MaxOutboundPeerConnections
 	}
 
 	count := p.outboundPeerCount()
@@ -592,7 +592,7 @@ func (p *PeerManager) acceptConnections() {
 func (p *PeerManager) addToOutboundSet(addr string, peer *Peer) bool {
 	p.outPeersLock.Lock()
 	defer p.outPeersLock.Unlock()
-	if len(p.outPeers) == MAX_OUTBOUND_PEER_CONNECTIONS {
+	if len(p.outPeers) == MaxOutboundPeerConnections {
 		// too many connections
 		return false
 	}
@@ -666,7 +666,7 @@ func (p *PeerManager) checkHostConnectionLimit(addr string) bool {
 	if !ok {
 		return true
 	}
-	return count < MAX_INBOUND_PEER_CONNECTIONS_FROM_SAME_HOST
+	return count < MaxInboundPeerConnectionsFromSameHost
 }
 
 // Helper to check if a peer address exists in the outbound set
@@ -809,5 +809,5 @@ func IsInitialBlockDownload(ledger Ledger, blockStore BlockStorage) (bool, int64
 	if CheckpointsEnabled && tipHeader.Height < LatestCheckpointHeight {
 		return true, tipHeader.Height, nil
 	}
-	return tipHeader.Time < (time.Now().Unix() - MAX_TIP_AGE), tipHeader.Height, nil
+	return tipHeader.Time < (time.Now().Unix() - MaxTipAge), tipHeader.Height, nil
 }

--- a/processor_test.go
+++ b/processor_test.go
@@ -7,14 +7,14 @@ import "testing"
 
 func TestBlockCreationReward(t *testing.T) {
 	var maxHalvings int64 = 64
-	var previous int64 = INITIAL_COINBASE_REWARD * 2
+	var previous int64 = InitialCoinbaseReward * 2
 	var halvings int64
 	for halvings = 0; halvings < maxHalvings; halvings++ {
-		var height int64 = halvings * BLOCKS_UNTIL_REWARD_HALVING
+		var height int64 = halvings * BlocksUntilRewardHalving
 		reward := BlockCreationReward(height)
-		if reward > INITIAL_COINBASE_REWARD {
+		if reward > InitialCoinbaseReward {
 			t.Fatalf("Reward %d at height %d greater than initial reward %d",
-				reward, height, INITIAL_COINBASE_REWARD)
+				reward, height, InitialCoinbaseReward)
 		}
 		if reward != previous/2 {
 			t.Fatalf("Reward %d at height %d not equal to half previous period reward",
@@ -22,7 +22,7 @@ func TestBlockCreationReward(t *testing.T) {
 		}
 		previous = reward
 	}
-	if BlockCreationReward(maxHalvings*BLOCKS_UNTIL_REWARD_HALVING) != 0 {
+	if BlockCreationReward(maxHalvings*BlocksUntilRewardHalving) != 0 {
 		t.Fatalf("Expected 0 reward by %d halving", maxHalvings)
 	}
 }
@@ -30,17 +30,17 @@ func TestBlockCreationReward(t *testing.T) {
 func TestComputeMaxTransactionsPerBlock(t *testing.T) {
 	var maxDoublings int64 = 64
 	var doublings int64
-	previous := INITIAL_MAX_TRANSACTIONS_PER_BLOCK / 2
+	previous := InitialMaxTransactionsPerBlock / 2
 	// verify the max is always doubling as expected
 	for doublings = 0; doublings < maxDoublings; doublings++ {
-		var height int64 = doublings * BLOCKS_UNTIL_TRANSACTIONS_PER_BLOCK_DOUBLING
+		var height int64 = doublings * BlocksUntilTransactionsPerBlockDoubling
 		max := computeMaxTransactionsPerBlock(height)
-		if max < INITIAL_MAX_TRANSACTIONS_PER_BLOCK {
+		if max < InitialMaxTransactionsPerBlock {
 			t.Fatalf("Max %d at height %d less than initial", max, height)
 		}
 		expect := previous * 2
-		if expect > MAX_TRANSACTIONS_PER_BLOCK {
-			expect = MAX_TRANSACTIONS_PER_BLOCK
+		if expect > MaxTransactionsPerBlock {
+			expect = MaxTransactionsPerBlock
 		}
 		if max != expect {
 			t.Fatalf("Max %d at height %d not equal to expected max %d",
@@ -51,7 +51,7 @@ func TestComputeMaxTransactionsPerBlock(t *testing.T) {
 			// walk back over the previous period and make sure:
 			// 1) the max is never greater than this period's first max
 			// 2) the max is always <= the previous as we walk back
-			for height -= 1; height >= (doublings-1)*BLOCKS_UNTIL_TRANSACTIONS_PER_BLOCK_DOUBLING; height-- {
+			for height -= 1; height >= (doublings-1)*BlocksUntilTransactionsPerBlockDoubling; height-- {
 				max2 := computeMaxTransactionsPerBlock(height)
 				if max2 > max {
 					t.Fatalf("Max %d at height %d is greater than next period's first max %d",
@@ -66,19 +66,19 @@ func TestComputeMaxTransactionsPerBlock(t *testing.T) {
 		}
 		previous = max
 	}
-	max := computeMaxTransactionsPerBlock(MAX_TRANSACTIONS_PER_BLOCK_EXCEEDED_AT_HEIGHT)
-	if max != MAX_TRANSACTIONS_PER_BLOCK {
+	max := computeMaxTransactionsPerBlock(MaxTransactionsPerBlockExceededAtHeight)
+	if max != MaxTransactionsPerBlock {
 		t.Fatalf("Expected %d at height %d, found %d",
-			MAX_TRANSACTIONS_PER_BLOCK, MAX_TRANSACTIONS_PER_BLOCK_EXCEEDED_AT_HEIGHT, max)
+			MaxTransactionsPerBlock, MaxTransactionsPerBlockExceededAtHeight, max)
 	}
-	max = computeMaxTransactionsPerBlock(MAX_TRANSACTIONS_PER_BLOCK_EXCEEDED_AT_HEIGHT + 1)
-	if max != MAX_TRANSACTIONS_PER_BLOCK {
+	max = computeMaxTransactionsPerBlock(MaxTransactionsPerBlockExceededAtHeight + 1)
+	if max != MaxTransactionsPerBlock {
 		t.Fatalf("Expected %d at height %d, found",
-			MAX_TRANSACTIONS_PER_BLOCK, MAX_TRANSACTIONS_PER_BLOCK_EXCEEDED_AT_HEIGHT+1)
+			MaxTransactionsPerBlock, MaxTransactionsPerBlockExceededAtHeight+1)
 	}
-	max = computeMaxTransactionsPerBlock(MAX_TRANSACTIONS_PER_BLOCK_EXCEEDED_AT_HEIGHT - 1)
-	if max >= MAX_TRANSACTIONS_PER_BLOCK {
+	max = computeMaxTransactionsPerBlock(MaxTransactionsPerBlockExceededAtHeight - 1)
+	if max >= MaxTransactionsPerBlock {
 		t.Fatalf("Expected less than max at height %d, found %d",
-			MAX_TRANSACTIONS_PER_BLOCK_EXCEEDED_AT_HEIGHT-1, max)
+			MaxTransactionsPerBlockExceededAtHeight-1, max)
 	}
 }

--- a/protocol.go
+++ b/protocol.go
@@ -220,7 +220,7 @@ type GetWorkMessage struct {
 // WorkMessage is used by a client to send work to perform to a mining peer.
 // The timestamp and nonce in the header can be manipulated by the mining peer.
 // It is the mining peer's responsibility to ensure the timestamp is not set below
-// the minimum timestamp and that the nonce does not exceed MAX_NUMBER (2^53-1).
+// the minimum timestamp and that the nonce does not exceed MaxNumber (2^53-1).
 // Type: "work"
 type WorkMessage struct {
 	WorkID  int32        `json:"work_id"`

--- a/transaction.go
+++ b/transaction.go
@@ -143,10 +143,10 @@ func (id *TransactionID) UnmarshalJSON(b []byte) error {
 func computeTransactionSeries(isCoinbase bool, height int64) int64 {
 	if isCoinbase {
 		// coinbases start using the new series right on time
-		return height/BLOCKS_UNTIL_NEW_SERIES + 1
+		return height/BlocksUntilNewSeries + 1
 	}
 
 	// otherwise don't start using a new series until 100 blocks in to mitigate
 	// potential reorg issues right around the switchover
-	return (height-100)/BLOCKS_UNTIL_NEW_SERIES + 1
+	return (height-100)/BlocksUntilNewSeries + 1
 }

--- a/transaction_queue_memory.go
+++ b/transaction_queue_memory.go
@@ -22,7 +22,7 @@ type TransactionQueueMemory struct {
 // NewTransactionQueueMemory returns a new NewTransactionQueueMemory instance.
 func NewTransactionQueueMemory(ledger Ledger) *TransactionQueueMemory {
 	// don't accept transactions that would leave an unspendable balance with this node
-	var minBalance int64 = MIN_AMOUNT_CRUZBITS + MIN_FEE_CRUZBITS
+	var minBalance int64 = MinAmountCruzbits + MinFeeCruzbits
 
 	return &TransactionQueueMemory{
 		txMap:        make(map[TransactionID]*list.Element),
@@ -121,7 +121,7 @@ func (t *TransactionQueueMemory) reprocessQueue(height int64) error {
 			// check maturity and expiration if included in the next block
 			!tx.IsMature(height+1) || tx.IsExpired(height+1) ||
 			// don't re-mine any now unconfirmed spam
-			tx.Fee < MIN_FEE_CRUZBITS || tx.Amount < MIN_AMOUNT_CRUZBITS {
+			tx.Fee < MinFeeCruzbits || tx.Amount < MinAmountCruzbits {
 			// transaction has been invalidated. remove and continue
 			id, err := tx.ID()
 			if err != nil {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -25,7 +25,7 @@ func TestTransaction(t *testing.T) {
 	}
 
 	// create the unsigned transaction
-	tx := NewTransaction(pubKey, pubKey2, 50*CRUZBITS_PER_CRUZ, 0, 0, 0, 0, "for lunch")
+	tx := NewTransaction(pubKey, pubKey2, 50*CruzbitsPerCruz, 0, 0, 0, 0, "for lunch")
 
 	// sign the transaction
 	if err := tx.Sign(privKey); err != nil {
@@ -70,7 +70,7 @@ func TestTransactionTestVector1(t *testing.T) {
 	}
 	pubKey2 := ed25519.PublicKey(pubKeyBytes2)
 
-	tx := NewTransaction(pubKey, pubKey2, 50*CRUZBITS_PER_CRUZ, 2*CRUZBITS_PER_CRUZ, 0, 0, 0, "for lunch")
+	tx := NewTransaction(pubKey, pubKey2, 50*CruzbitsPerCruz, 2*CruzbitsPerCruz, 0, 0, 0, "for lunch")
 	tx.Time = 1558565474
 	tx.Nonce = 2019727887
 

--- a/wallet/main.go
+++ b/wallet/main.go
@@ -31,7 +31,7 @@ import (
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
-	DefaultPeer := "127.0.0.1:" + strconv.Itoa(DEFAULT_CRUZBIT_PORT)
+	DefaultPeer := "127.0.0.1:" + strconv.Itoa(DefaultCruzbitPort)
 	peerPtr := flag.String("peer", DefaultPeer, "Address of a peer to connect to")
 	dbPathPtr := flag.String("walletdb", "", "Path to a wallet database (created if it doesn't exist)")
 	tlsVerifyPtr := flag.Bool("tlsverify", false, "Verify the TLS certificate of the peer is signed by a recognized CA and the host matches the CN")
@@ -47,7 +47,7 @@ func main() {
 	// add default port, if one was not supplied
 	i := strings.LastIndex(*peerPtr, ":")
 	if i < 0 {
-		*peerPtr = *peerPtr + ":" + strconv.Itoa(DEFAULT_CRUZBIT_PORT)
+		*peerPtr = *peerPtr + ":" + strconv.Itoa(DefaultCruzbitPort)
 	}
 
 	// load genesis block
@@ -277,14 +277,14 @@ func main() {
 					fmt.Printf("Error: %s\n", err)
 					break
 				}
-				amount := roundFloat(float64(balance), 8) / CRUZBITS_PER_CRUZ
+				amount := roundFloat(float64(balance), 8) / CruzbitsPerCruz
 				fmt.Printf("%4d: %s %16.8f\n",
 					i+1,
 					base64.StdEncoding.EncodeToString(pubKey[:]),
 					amount)
 				total += balance
 			}
-			amount := roundFloat(float64(total), 8) / CRUZBITS_PER_CRUZ
+			amount := roundFloat(float64(total), 8) / CruzbitsPerCruz
 			fmt.Printf("%s: %.8f\n", aurora.Bold("Total"), amount)
 
 		case "send":
@@ -403,7 +403,7 @@ func main() {
 				break
 			}
 			var total int64
-			lastHeight := tipHeader.Height - COINBASE_MATURITY
+			lastHeight := tipHeader.Height - CoinbaseMaturity
 		gpkt:
 			for i, pubKey := range pubKeys {
 				var rewards, startHeight int64 = 0, lastHeight + 1
@@ -429,14 +429,14 @@ func main() {
 						break
 					}
 				}
-				amount := roundFloat(float64(rewards), 8) / CRUZBITS_PER_CRUZ
+				amount := roundFloat(float64(rewards), 8) / CruzbitsPerCruz
 				fmt.Printf("%4d: %s %16.8f\n",
 					i+1,
 					base64.StdEncoding.EncodeToString(pubKey[:]),
 					amount)
 				total += rewards
 			}
-			amount := roundFloat(float64(total), 8) / CRUZBITS_PER_CRUZ
+			amount := roundFloat(float64(total), 8) / CruzbitsPerCruz
 			fmt.Printf("%s: %.8f\n", aurora.Bold("Total"), amount)
 
 		case "verify":
@@ -601,7 +601,7 @@ func sendTransaction(wallet *Wallet) (TransactionID, error) {
 	if amount < minAmount {
 		return TransactionID{}, fmt.Errorf(
 			"The peer's minimum amount to relay transactions is %.8f",
-			roundFloat(float64(minAmount), 8)/CRUZBITS_PER_CRUZ)
+			roundFloat(float64(minAmount), 8)/CruzbitsPerCruz)
 	}
 
 	// prompt for fee
@@ -612,7 +612,7 @@ func sendTransaction(wallet *Wallet) (TransactionID, error) {
 	if fee < minFee {
 		return TransactionID{}, fmt.Errorf(
 			"The peer's minimum required fee to relay transactions is %.8f",
-			roundFloat(float64(minFee), 8)/CRUZBITS_PER_CRUZ)
+			roundFloat(float64(minFee), 8)/CruzbitsPerCruz)
 	}
 
 	// prompt for memo
@@ -622,9 +622,9 @@ func sendTransaction(wallet *Wallet) (TransactionID, error) {
 		return TransactionID{}, err
 	}
 	memo := strings.TrimSpace(text)
-	if len(memo) > MAX_MEMO_LENGTH {
+	if len(memo) > MaxMemoLength {
 		return TransactionID{}, fmt.Errorf("Maximum memo length (%d) exceeded (%d)",
-			MAX_MEMO_LENGTH, len(memo))
+			MaxMemoLength, len(memo))
 	}
 
 	// create and send send it. by default the transaction expires if not mined within 3 blocks from now
@@ -666,7 +666,7 @@ func promptForValue(prompt string, rightJustify int, reader *bufio.Reader) (int6
 	if err != nil {
 		return 0, fmt.Errorf("Invalid value")
 	}
-	valueInt := int64(roundFloat(value, 8) * CRUZBITS_PER_CRUZ)
+	valueInt := int64(roundFloat(value, 8) * CruzbitsPerCruz)
 	return valueInt, nil
 }
 
@@ -747,9 +747,9 @@ func showTransaction(w *Wallet, tx *Transaction, height int64) {
 		fmt.Printf("%7v: %s\n", aurora.Bold("From"), base64.StdEncoding.EncodeToString(tx.From))
 	}
 	fmt.Printf("%7v: %s\n", aurora.Bold("To"), base64.StdEncoding.EncodeToString(tx.To))
-	fmt.Printf("%7v: %.8f\n", aurora.Bold("Amount"), roundFloat(float64(tx.Amount), 8)/CRUZBITS_PER_CRUZ)
+	fmt.Printf("%7v: %.8f\n", aurora.Bold("Amount"), roundFloat(float64(tx.Amount), 8)/CruzbitsPerCruz)
 	if tx.Fee > 0 {
-		fmt.Printf("%7v: %.8f\n", aurora.Bold("Fee"), roundFloat(float64(tx.Fee), 8)/CRUZBITS_PER_CRUZ)
+		fmt.Printf("%7v: %.8f\n", aurora.Bold("Fee"), roundFloat(float64(tx.Fee), 8)/CruzbitsPerCruz)
 	}
 	if len(tx.Memo) > 0 {
 		fmt.Printf("%7v: %s\n", aurora.Bold("Memo"), tx.Memo)

--- a/wallet/main_test.go
+++ b/wallet/main_test.go
@@ -8,41 +8,41 @@ import (
 
 func TestRoundFloat(t *testing.T) {
 	value, _ := strconv.ParseFloat("4.89", 64)
-	amount := int64(roundFloat(value, 8) * CRUZBITS_PER_CRUZ)
+	amount := int64(roundFloat(value, 8) * CruzbitsPerCruz)
 	if amount != 489000000 {
 		t.Fatalf("Expected %d, got %d\n", 489000000, amount)
 	}
-	f := roundFloat(float64(amount), 8) / CRUZBITS_PER_CRUZ
+	f := roundFloat(float64(amount), 8) / CruzbitsPerCruz
 	if f != 4.89 {
 		t.Fatalf("Expected 4.89, got: %v\n", f)
 	}
 
 	value, _ = strconv.ParseFloat("0.00000001", 64)
-	amount = int64(roundFloat(value, 8) * CRUZBITS_PER_CRUZ)
+	amount = int64(roundFloat(value, 8) * CruzbitsPerCruz)
 	if amount != 1 {
 		t.Fatalf("Expected %d, got %d\n", 1, amount)
 	}
-	f = roundFloat(float64(amount), 8) / CRUZBITS_PER_CRUZ
+	f = roundFloat(float64(amount), 8) / CruzbitsPerCruz
 	if f != 0.00000001 {
 		t.Fatalf("Expected 0.00000001, got: %v\n", f)
 	}
 
 	value, _ = strconv.ParseFloat("1.00000001", 64)
-	amount = int64(roundFloat(value, 8) * CRUZBITS_PER_CRUZ)
+	amount = int64(roundFloat(value, 8) * CruzbitsPerCruz)
 	if amount != 100000001 {
 		t.Fatalf("Expected %d, got %d\n", 100000001, amount)
 	}
-	f = roundFloat(float64(amount), 8) / CRUZBITS_PER_CRUZ
+	f = roundFloat(float64(amount), 8) / CruzbitsPerCruz
 	if f != 1.00000001 {
 		t.Fatalf("Expected 1.00000001, got: %v\n", f)
 	}
 
 	value, _ = strconv.ParseFloat("123", 64)
-	amount = int64(roundFloat(value, 8) * CRUZBITS_PER_CRUZ)
+	amount = int64(roundFloat(value, 8) * CruzbitsPerCruz)
 	if amount != 12300000000 {
 		t.Fatalf("Expected %d, got %d\n", 12300000000, amount)
 	}
-	f = roundFloat(float64(amount), 8) / CRUZBITS_PER_CRUZ
+	f = roundFloat(float64(amount), 8) / CruzbitsPerCruz
 	if f != 123.0 {
 		t.Fatalf("Expected 123.0, got: %v\n", f)
 	}


### PR DESCRIPTION
The primary change here is the renaming of all global constants from UPPER_SNAKE_CASE to PascalCase in keeping to Go recommendations. 
* https://go.dev/doc/effective_go#mixed-caps
* https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps

This opportunity was also used to increase the "max tip age" from 1 day to 30 days. This helps to prevent a stalled chain from miners refusing to mine if the last block was found more than 24 hours ago (a mass exodus of miners, for example). This was first proposed by Simon Kühn here: https://github.com/Sykh/cruzbit/commit/d51d30423c6ed46821682178e7957a8f551ea227