### PR TITLE
Prevent random peer drop under max count

### DIFF
--- a/peer_manager.go
+++ b/peer_manager.go
@@ -232,7 +232,7 @@ func (p *PeerManager) run() {
 			// handle listening for inbound peers
 			p.listenForPeers(ctx)
 
-			if p.dnsseed && rand.Intn(2) == 1 {
+			if p.dnsseed && p.outboundPeerCount() >= MaxOutboundPeerConnections && rand.Intn(2) == 1 {
 				// drop a peer so we can try another
 				p.dropRandomPeer()
 			}


### PR DESCRIPTION
Don't "randomly drop" outbound peer connections if the number of connections available is below maximum connection limit. The random drop facilitates communicating with a variety of peers (avoids permanently connecting to the same set), but serves no purpose if there are additional outbound slots open.