### PR TITLE
Fix IPv6 hostport address string creation

### DIFF
--- a/peer_manager.go
+++ b/peer_manager.go
@@ -410,7 +410,7 @@ func (p *PeerManager) connect(ctx context.Context, addr string) (int, *Peer, err
 	var myAddress string
 	if p.accepting && p.open {
 		// advertise ourself as open
-		myAddress = p.myIP + ":" + strconv.Itoa(p.port)
+		myAddress = net.JoinHostPort(p.myIP, strconv.Itoa(p.port))
 	}
 
 	// connect to the peer


### PR DESCRIPTION
Leverages an existing dependency to properly create 'hostport' strings for IPv6 addresses.

Manually concatenating host and port strings by merely joining them with a colon breaks IPv6 addresses, which must be enclosed in square brackets. For example, `2600:3c00::f03c:91ff:fe8a:4d38:8831` is invalid, while `[2600:3c00::f03c:91ff:fe8a:4d38]:8831` is valid.